### PR TITLE
Fix alt body base64 encoding with long lines

### DIFF
--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -2120,8 +2120,9 @@ class PHPMailer
             $altBodyEncoding = '7bit';
             $altBodyCharSet = 'us-ascii';
         }
-        //If lines are too long, change to quoted-printable transfer encoding
-        if (self::hasLineLongerThanMax($this->AltBody)) {
+        //If lines are too long, and we're not already using an encoding that will shorten them,
+        //change to quoted-printable transfer encoding
+        if ('base64' != $altBodyEncoding and self::hasLineLongerThanMax($this->AltBody)) {
             $altBodyEncoding = 'quoted-printable';
         }
         //Use this as a preamble in all multipart message types


### PR DESCRIPTION
Extend fix from https://github.com/PHPMailer/PHPMailer/commit/9269a656ca2dca1ab2653c4abe7c0f796f31af33 to apply to alt body as well.