### PR TITLE
Fix exception thrown for connection issue

### DIFF
--- a/src/SMTP.php
+++ b/src/SMTP.php
@@ -332,6 +332,11 @@ class SMTP
 
         $this->smtp_conn = $this->getSMTPConnection($host, $port, $timeout, $options);
 
+        if ($this->smtp_conn === false) {
+            //Error info already set inside `getSMTPConnection()`
+            return false;
+        }
+        
         $this->edebug('Connection: opened', self::DEBUG_CONNECTION);
         // SMTP server can take longer to respond, give longer timeout for first read
         // Windows does not have support for this timeout function


### PR DESCRIPTION
Currently, if the smtp connection fails an exception will be thrown at line 344. It is something along the lines `stream_set_timeout() expected object but got bool`. Thus the `connect()` function throws an exception instead of returning false. 

The consequence is that the smtp connection is not closed in `PHPMailer::2051`. Also the exception is not a `ConnectivityException` as should be the case through `PHPMailer::1859` and `Mailer::157`.

The added piece of code I added is part of the latest stable release of PHPMailer so should be safe.